### PR TITLE
also look for credentials in files ending in '.gpg'

### DIFF
--- a/lib/Config/Identity.pm
+++ b/lib/Config/Identity.pm
@@ -3,6 +3,8 @@ package Config::Identity;
 
 =head1 SYNOPSIS
 
+Note: we also look for the identity files with a '.gpg' suffix.
+
 PAUSE:
 
     use Config::Identity::PAUSE;
@@ -37,11 +39,21 @@ For PAUSE access, an identity is a C<user>/C<password> pair
 
 =head2 %identity = Config::Identity->load_best( <stub> )
 
-First attempt to load an identity from $HOME/.<stub>-identity
+We attempt to load identities from files (in this order:)
 
-If that file does not exist, then attempt to load an identity from $HOME/.<stub>
+=over 4
 
-The file may be optionally GnuPG encrypted
+=item C<$HOME/.<stub>-identity.gpg>
+
+=item C<$HOME/.<stub>-identity>
+
+=item C<$HOME/.<stub>.gpg>
+
+=item C<$HOME/.<stub>>
+
+=back
+
+The file may be optionally GnuPG encrypted, regardless of '.gpg' suffix.
 
 %identity will be populated like so:
 
@@ -154,8 +166,8 @@ sub best {
     croak "Missing stub" unless defined $stub && length $stub;
 
     for my $i0 ( ".$stub-identity", ".$stub" ) {
-        for my $i1 ( "." ) {
-            my $path = File::Spec->catfile( $base, $i1, $i0 );
+        for my $i1 ( ".gpg", q{} ) {
+            my $path = File::Spec->catfile( $base, '.', "$i0$i1" );
             return $path if -f $path;
         }
     }

--- a/t/find-gpg.t
+++ b/t/find-gpg.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+# check to ensure that we can find the various files we should be looking for
+
+use Test::More;
+use Test::TempDir 'scratch';
+use Directory::Scratch;
+use Path::Class;
+use Readonly;
+
+use aliased 'Config::Identity' => 'CI';
+
+Readonly my $STUB => 'foo';
+
+test_file_finder(".$STUB$_")
+    for q{}, qw{ .gpg -identity -identity.gpg };
+
+done_testing; # <===================
+
+sub test_file_finder {
+    my $filename = shift @_;
+
+    my $ds = scratch;
+    $ds->touch($filename);
+
+    my $found = CI->best($STUB, $ds->base);
+    ok $found, 'found a file!';
+    return unless $found;
+
+    $found = file($found)->basename;
+
+    $ds->cleanup
+        if is $found, $filename, "found $filename correctly";
+
+    return;
+}


### PR DESCRIPTION
Oftentimes people's editors are rigged to automatically de/encrypt files 
ending in '.gpg'; this change causes CI to look for identity files ending
with that suffix as well.
