### PR TITLE
Use load_check in SYNOPSIS

### DIFF
--- a/lib/Config/Identity.pm
+++ b/lib/Config/Identity.pm
@@ -11,7 +11,7 @@ PAUSE:
     # 2. Decrypt the found file (if necessary), read, and parse it
     # 3. Throw an exception unless  %identity has 'user' and 'password' defined
 
-    my %identity = Config::Identity::PAUSE->load;
+    my %identity = Config::Identity::PAUSE->load_check;
     print "user: $identity{user} password: $identity{password}\n";
      
 GitHub API:
@@ -22,7 +22,7 @@ GitHub API:
     # 2. Decrypt the found file (if necessary) read, and parse it
     # 3. Throw an exception unless %identity has 'login' and 'token' defined
 
-    my %identity = Config::Identity::PAUSE->load;
+    my %identity = Config::Identity::PAUSE->load_check;
     print "login: $identity{login} token: $identity{token}\n";
 
 =head1 DESCRIPTION


### PR DESCRIPTION
The current SYNOPSIS says an exception is thrown if the required fields
aren't there, but calls 'load', not 'load_check'.  This commit
changes that so it behaves as documented.
