### PR TITLE
Add a generic load_check method

### DIFF
--- a/lib/Config/Identity.pm
+++ b/lib/Config/Identity.pm
@@ -210,7 +210,7 @@ sub load_best {
     my $self = shift;
     my $stub = shift;
 
-    die "Unable to find .$stub-identity or .$stub" unless my $path = $self->best( $stub );
+    croak "Unable to find .$stub-identity or .$stub" unless my $path = $self->best( $stub );
     return $self->load( $path );
 }
 

--- a/t/assets/pause/.pause-alternate
+++ b/t/assets/pause/.pause-alternate
@@ -1,2 +1,3 @@
 username alternate
 password xyzzy
+wont_parse_empty


### PR DESCRIPTION
This PR adds `Config::Identity->load_check` for generic use
to load a stub file and check for a required set of keys.

```
Config::Identity->load_check( $stub, [qw/user pass/]);

Config::Identity->load_check( $stub, sub { ... } );
```

This will allow Config::Identity to be used for simple cases other
than PAUSE and GitHub without requiring a subclass or requiring users
to write their own generic missing key checks.

The PR also changes a die to a croak for consistency.
